### PR TITLE
Change `fromXPC(_:)` to using `XPCDictionary.init(minimumCapacity:)`

### DIFF
--- a/SwiftXPC/SwiftXPC.swift
+++ b/SwiftXPC/SwiftXPC.swift
@@ -145,7 +145,8 @@ Converts an xpc_object_t dictionary to a Dictionary of XPCRepresentable objects.
 - returns: Converted Dictionary of XPCRepresentable objects.
 */
 public func fromXPC(xpcObject: xpc_object_t) -> XPCDictionary {
-    var dict = XPCDictionary()
+    let count = xpc_dictionary_get_count(xpcObject)
+    var dict = XPCDictionary(minimumCapacity: count)
     xpc_dictionary_apply(xpcObject) { key, value in
         if let key = String(UTF8String: key), let value = fromXPCGeneral(value) {
             dict[key] = value


### PR DESCRIPTION
By applying this, the duration of `fromXPC(_:)` on linting Carthage is reduced from 2994ms to 1956ms.
from:
<img width="824" alt="screenshot 2016-01-10 22 12 14" src="https://cloud.githubusercontent.com/assets/33430/12221660/836f20de-b7e7-11e5-8307-766aff47e21e.png">
to:
<img width="814" alt="screenshot 2016-01-10 22 12 31" src="https://cloud.githubusercontent.com/assets/33430/12221661/8746842c-b7e7-11e5-8a3d-bc4498c61596.png">
