### PR TITLE
Change `==` operator for `XPCRepresentable` from public to internal

### DIFF
--- a/SwiftXPC/XPCType.swift
+++ b/SwiftXPC/XPCType.swift
@@ -10,7 +10,16 @@ import Foundation
 import XPC
 
 /// Protocol to group Swift/Objective-C types that can be represented as XPC types.
-public protocol XPCRepresentable {}
+public protocol XPCRepresentable {
+    func isEqualTo(rhs: XPCRepresentable) -> Bool
+}
+
+extension XPCRepresentable {
+    public func isEqualTo(rhs: XPCRepresentable) -> Bool {
+        return self == rhs
+    }
+}
+
 extension Array: XPCRepresentable {}
 extension Dictionary: XPCRepresentable {}
 extension String: XPCRepresentable {}
@@ -53,12 +62,12 @@ public typealias XPCDictionary = [String: XPCRepresentable]
 // MARK: Equatable
 
 /// Enable comparison of XPCRepresentable objects.
-public func !=(lhs: XPCRepresentable, rhs: XPCRepresentable) -> Bool {
+internal func !=(lhs: XPCRepresentable, rhs: XPCRepresentable) -> Bool {
     return !(lhs == rhs)
 }
 
 /// Enable comparison of XPCRepresentable objects.
-public func ==(lhs: XPCRepresentable, rhs: XPCRepresentable) -> Bool {
+internal func ==(lhs: XPCRepresentable, rhs: XPCRepresentable) -> Bool {
     switch lhs {
     case let lhs as XPCArray:
         for (idx, value) in lhs.enumerate() {

--- a/SwiftXPCTests/SwiftXPCTests.swift
+++ b/SwiftXPCTests/SwiftXPCTests.swift
@@ -23,7 +23,7 @@ func testEqualityOfXPCRoundtrip(object: XPCRepresentable) {
         XCTFail("XPC-converted object is nil")
     }
 
-    XCTAssertTrue(object == outObject!, "Object \(object) was not equal to result \(outObject)")
+    XCTAssertTrue(object.isEqualTo(outObject!), "Object \(object) was not equal to result \(outObject)")
 }
 
 class SwiftXPCTests: XCTestCase {


### PR DESCRIPTION
Add `XPCRepresentable.isEqualTo(_:)` instead of that.
Fix #8